### PR TITLE
Tensor construction warnings

### DIFF
--- a/nflows/distributions/__init__.py
+++ b/nflows/distributions/__init__.py
@@ -9,5 +9,4 @@ from nflows.distributions.normal import (
 from nflows.distributions.uniform import (
     LotkaVolterraOscillating,
     MG1Uniform,
-    TweakedUniform,
 )

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -34,12 +34,8 @@ class PointwiseAffineTransform(Transform):
         if scale == 0.0:
             raise ValueError("Scale cannot be zero.")
 
-        self.register_buffer(
-            "_shift", ensure_tensor(shift if (shift is not None) else 0.0)
-        )
-        self.register_buffer(
-            "_scale", ensure_tensor(scale if (scale is not None) else 1.0)
-        )
+        self.register_buffer("_shift", shift)
+        self.register_buffer("_scale", scale)
 
     @property
     def _log_scale(self):

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -1,13 +1,12 @@
 """Implementations of some standard transforms."""
 
-from typing import Optional, Union
+from typing import Optional, Union, Tuple, Iterable
 import warnings
 
 import torch
 from torch import Tensor
 
 from nflows.transforms.base import Transform
-from nflows.utils.torchutils import ensure_tensor, numel
 
 
 class IdentityTransform(Transform):
@@ -29,7 +28,7 @@ class PointwiseAffineTransform(Transform):
         self, shift: Union[Tensor, float] = 0.0, scale: Union[Tensor, float] = 1.0,
     ):
         super().__init__()
-        shift, scale = map(ensure_tensor, (shift, scale))
+        shift, scale = map(torch.as_tensor, (shift, scale))
 
         if not (scale > 0.0).all():
             raise ValueError("Scale must be strictly positive.")
@@ -38,21 +37,21 @@ class PointwiseAffineTransform(Transform):
         self.register_buffer("_scale", scale)
 
     @property
-    def _log_scale(self):
+    def _log_scale(self) -> Tensor:
         return torch.log(self._scale)
 
     # XXX memoize?
-    def _batch_logabsdet(self, batch_shape: torch.Size):
+    def _batch_logabsdet(self, batch_shape: Iterable[int]) -> Tensor:
         """Return log abs det with input batch shape."""
 
-        if numel(self._log_scale) > 1:
+        if self._log_scale.numel() > 1:
             return self._log_scale.expand(batch_shape).sum()
         else:
             # when log_scale is a scalar, we use n*log_scale, which is more
             # numerically accurate than \sum_1^n log_scale.
-            return self._log_scale * numel(batch_shape)
+            return self._log_scale * torch.Size(batch_shape).numel()
 
-    def forward(self, inputs: Tensor, context=Optional[Tensor]):
+    def forward(self, inputs: Tensor, context=Optional[Tensor]) -> Tuple[Tensor]:
         batch_size, *batch_shape = inputs.size()
 
         # RuntimeError here => shift/scale not broadcastable to input
@@ -61,7 +60,7 @@ class PointwiseAffineTransform(Transform):
 
         return outputs, logabsdet
 
-    def inverse(self, inputs: Tensor, context=Optional[Tensor]):
+    def inverse(self, inputs: Tensor, context=Optional[Tensor]) -> Tuple[Tensor]:
         batch_size, *batch_shape = inputs.size()
         outputs = (inputs - self._shift) / self._scale
         logabsdet = -self._batch_logabsdet(batch_shape).expand(batch_size)

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -27,6 +27,7 @@ class PointwiseAffineTransform(Transform):
         scale: torch.Tensor = torch.tensor(1.0),
     ):
         super().__init__()
+        shift, scale = map(ensure_tensor, (shift, scale))
 
         if shift is None and scale is None:
             raise ValueError("At least one of scale and shift must be provided.")

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -39,7 +39,7 @@ class PointwiseAffineTransform(Transform):
 
     @property
     def _log_scale(self):
-        return torch.log(torch.abs(self._scale))
+        return torch.log(self._scale)
 
     def forward(self, inputs, context=None):
         batch_size = inputs.shape[0]

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -1,5 +1,8 @@
 """Implementations of some standard transforms."""
 
+from typing import Optional
+import warnings
+import numpy as np
 import torch
 from nflows.utils.torchutils import ensure_tensor
 from nflows.transforms.base import Transform
@@ -8,12 +11,12 @@ from nflows.transforms.base import Transform
 class IdentityTransform(Transform):
     """Transform that leaves input unchanged."""
 
-    def forward(self, inputs, context=None):
-        batch_size = inputs.shape[0]
-        logabsdet = torch.zeros(batch_size)
+    def forward(self, inputs: torch.Tensor, context=Optional[torch.Tensor]):
+        num_batches = inputs.shape[0]
+        logabsdet = torch.zeros(num_batches)
         return inputs, logabsdet
 
-    def inverse(self, inputs, context=None):
+    def inverse(self, inputs: torch.Tensor, context=Optional[torch.Tensor]):
         return self(inputs, context)
 
 

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -20,10 +20,12 @@ class IdentityTransform(Transform):
         return self(inputs, context)
 
 
-class AffineScalarTransform(Transform):
-    """Computes X = X * scale + shift, where scale and shift are scalars, and scale is non-zero."""
-
-    def __init__(self, shift=None, scale=None):
+class PointwiseAffineTransform(Transform):
+    def __init__(
+        self,
+        shift: torch.Tensor = torch.tensor(0.0),
+        scale: torch.Tensor = torch.tensor(1.0),
+    ):
         super().__init__()
 
         if shift is None and scale is None:
@@ -57,20 +59,23 @@ class AffineScalarTransform(Transform):
         return outputs, logabsdet
 
 
-class AffineTransform(Transform):
-    def __init__(self, shift=None, scale=None):
-        super().__init__()
+class AffineTransform(PointwiseAffineTransform):
+    def __init__(
+        self,
+        shift: torch.Tensor = torch.tensor(0.0),
+        scale: torch.Tensor = torch.tensor(1.0),
+    ):
 
-        self.register_buffer(
-            "_shift", ensure_tensor(shift if (shift is not None) else 0.0)
-        )
-        self.register_buffer(
-            "_scale", ensure_tensor(scale if (scale is not None) else 1.0)
-        )
+        warnings.warn("Use PointwiseAffineTransform", DeprecationWarning)
 
-    @property
-    def _log_scale(self):
-        return torch.log(torch.abs(self._scale))
+        if shift is None:
+            warnings.warn("`shift=None` deprecated; default is 0.0")
+            shift = torch.tensor(0.0)
+        if scale is None:
+            warnings.warn("`scale=None` deprecated; default is 1.0.")
+            scale = torch.tensor(1.0)
+
+        super().__init__(shift, scale)
 
     def forward(self, inputs, context=None):
         batch_size = inputs.shape[0]
@@ -78,8 +83,4 @@ class AffineTransform(Transform):
         logabsdet = self._log_scale.reshape(1, -1).repeat(batch_size, 1).sum(dim=-1)
         return outputs, logabsdet
 
-    def inverse(self, inputs, context=None):
-        batch_size = inputs.shape[0]
-        outputs = (inputs - self._shift) / self._scale
-        logabsdet = -self._log_scale.reshape(1, -1).repeat(batch_size, 1).sum(dim=-1)
-        return outputs, logabsdet
+AffineScalarTransform = AffineTransform

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -29,10 +29,10 @@ class PointwiseAffineTransform(Transform):
         super().__init__()
         shift, scale = map(ensure_tensor, (shift, scale))
 
-        if shift is None and scale is None:
-            raise ValueError("At least one of scale and shift must be provided.")
-        if scale == 0.0:
-            raise ValueError("Scale cannot be zero.")
+        # reject scales < ~0 (upto dtype precision)
+        is_scale_positive = torch.isfinite(torch.log(scale)).any()
+        if not is_scale_positive:
+            raise ValueError("Scale must be strictly positive.")
 
         self.register_buffer("_shift", shift)
         self.register_buffer("_scale", scale)

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -1,7 +1,7 @@
 """Implementations of some standard transforms."""
 
 import torch
-
+from nflows.utils.torchutils import ensure_tensor
 from nflows.transforms.base import Transform
 
 
@@ -29,10 +29,10 @@ class AffineScalarTransform(Transform):
             raise ValueError("Scale cannot be zero.")
 
         self.register_buffer(
-            "_shift", torch.tensor(shift if (shift is not None) else 0.0)
+            "_shift", ensure_tensor(shift if (shift is not None) else 0.0)
         )
         self.register_buffer(
-            "_scale", torch.tensor(scale if (scale is not None) else 1.0)
+            "_scale", ensure_tensor(scale if (scale is not None) else 1.0)
         )
 
     @property
@@ -41,14 +41,14 @@ class AffineScalarTransform(Transform):
 
     def forward(self, inputs, context=None):
         batch_size = inputs.shape[0]
-        num_dims = torch.prod(torch.tensor(inputs.shape[1:]), dtype=torch.float)
+        num_dims = torch.prod(ensure_tensor(inputs.shape[1:]), dtype=torch.float)
         outputs = inputs * self._scale + self._shift
         logabsdet = torch.full([batch_size], self._log_scale * num_dims)
         return outputs, logabsdet
 
     def inverse(self, inputs, context=None):
         batch_size = inputs.shape[0]
-        num_dims = torch.prod(torch.tensor(inputs.shape[1:]), dtype=torch.float)
+        num_dims = torch.prod(ensure_tensor(inputs.shape[1:]), dtype=torch.float)
         outputs = (inputs - self._shift) / self._scale
         logabsdet = torch.full([batch_size], -self._log_scale * num_dims)
         return outputs, logabsdet
@@ -59,10 +59,10 @@ class AffineTransform(Transform):
         super().__init__()
 
         self.register_buffer(
-            "_shift", torch.tensor(shift if (shift is not None) else 0.0)
+            "_shift", ensure_tensor(shift if (shift is not None) else 0.0)
         )
         self.register_buffer(
-            "_scale", torch.tensor(scale if (scale is not None) else 1.0)
+            "_scale", ensure_tensor(scale if (scale is not None) else 1.0)
         )
 
     @property

--- a/nflows/utils/torchutils.py
+++ b/nflows/utils/torchutils.py
@@ -160,8 +160,8 @@ def get_temperature(max_value, bound=1 - 1e-3):
     return temperature
 
 
-def notinfnotnan(x):
-    return torch.all(~torch.isnan(x)) and torch.all(~torch.isinf(x))
+def notinfnotnan(x: torch.Tensor) -> torch.Tensor[bool]:
+    return torch.isfinite(x).all()
 
 
 def gaussian_kde_log_eval(samples, query):

--- a/nflows/utils/torchutils.py
+++ b/nflows/utils/torchutils.py
@@ -175,25 +175,3 @@ def gaussian_kde_log_eval(samples, query):
     d = -np.log(N) - (D / 2) * np.log(2 * np.pi) - D * np.log(std)
     c += d
     return torch.logsumexp(c, dim=-1)
-
-
-def ensure_tensor(arg):
-    """Return argument cast into a tensor if it's not one already."""
-
-    if not isinstance(arg, torch.Tensor):
-        return torch.tensor(arg)
-
-    return arg
-
-
-def numel(t: Union[torch.Tensor, torch.Size]) -> int:
-    """Return number of elements given a tensor or its size.
-
-    Args:
-        t: a Tensor or tensor's Size.
-    """
-
-    if isinstance(t, torch.Tensor):
-        t = t.size()
-
-    return int(np.prod(t))

--- a/nflows/utils/torchutils.py
+++ b/nflows/utils/torchutils.py
@@ -161,7 +161,7 @@ def get_temperature(max_value, bound=1 - 1e-3):
     return temperature
 
 
-def notinfnotnan(x: torch.Tensor) -> torch.Tensor[bool]:
+def notinfnotnan(x: torch.Tensor) -> torch.Tensor:
     return torch.isfinite(x).all()
 
 

--- a/nflows/utils/torchutils.py
+++ b/nflows/utils/torchutils.py
@@ -174,3 +174,12 @@ def gaussian_kde_log_eval(samples, query):
     d = -np.log(N) - (D / 2) * np.log(2 * np.pi) - D * np.log(std)
     c += d
     return torch.logsumexp(c, dim=-1)
+
+
+def ensure_tensor(arg):
+    """Return argument cast into a tensor if it's not one already."""
+
+    if not isinstance(arg, torch.Tensor):
+        return torch.tensor(arg)
+
+    return arg

--- a/nflows/utils/torchutils.py
+++ b/nflows/utils/torchutils.py
@@ -1,5 +1,6 @@
 """Various PyTorch utility functions."""
 
+from typing import Union
 import numpy as np
 import torch
 
@@ -183,3 +184,16 @@ def ensure_tensor(arg):
         return torch.tensor(arg)
 
     return arg
+
+
+def numel(t: Union[torch.Tensor, torch.Size]) -> int:
+    """Return number of elements given a tensor or its size.
+
+    Args:
+        t: a Tensor or tensor's Size.
+    """
+
+    if isinstance(t, torch.Tensor):
+        t = t.size()
+
+    return int(np.prod(t))

--- a/tests/transforms/coupling_test.py
+++ b/tests/transforms/coupling_test.py
@@ -34,7 +34,7 @@ def create_coupling_transform(cls, shape, **kwargs):
 batch_size = 10
 
 
-class AffineTransformTest(TransformTest):
+class AffineCouplingTransformTest(TransformTest):
     shapes = [[20], [2, 4, 4]]
 
     def test_forward(self):

--- a/tests/utils/torchutils_test.py
+++ b/tests/utils/torchutils_test.py
@@ -97,15 +97,6 @@ class TorchUtilsTest(torchtestcase.TorchTestCase):
         idx = torchutils.searchsorted(bin_locations, inputs)
         self.assertEqual(idx.shape, inputs.shape)
 
-    def test_ensure_tensor(self):
-        a_tensor = torch.randn([1, 2])
-        an_array = np.array([1, 2, 3])
-        a_scalar = 2.0
-
-        assert isinstance(torchutils.ensure_tensor(a_tensor), torch.Tensor)
-        assert isinstance(torchutils.ensure_tensor(an_array), torch.Tensor)
-        assert isinstance(torchutils.ensure_tensor(a_scalar), torch.Tensor)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils/torchutils_test.py
+++ b/tests/utils/torchutils_test.py
@@ -1,6 +1,7 @@
 """Tests for the PyTorch utility functions."""
 
 import unittest
+import numpy as np
 
 import torch
 import torchtestcase
@@ -95,6 +96,15 @@ class TorchUtilsTest(torchtestcase.TorchTestCase):
         inputs = torch.rand(*shape)
         idx = torchutils.searchsorted(bin_locations, inputs)
         self.assertEqual(idx.shape, inputs.shape)
+
+    def test_ensure_tensor(self):
+        a_tensor = torch.randn([1, 2])
+        an_array = np.array([1, 2, 3])
+        a_scalar = 2.0
+
+        assert isinstance(torchutils.ensure_tensor(a_tensor), torch.Tensor)
+        assert isinstance(torchutils.ensure_tensor(an_array), torch.Tensor)
+        assert isinstance(torchutils.ensure_tensor(a_scalar), torch.Tensor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a little helper function to prevent tensor construction warnings when passing a `torch.Tensor`-typed argument to `torch.tensor()`.