### PR TITLE
Register ActNorm.initialized as buffer

### DIFF
--- a/nflows/transforms/normalization.py
+++ b/nflows/transforms/normalization.py
@@ -154,7 +154,7 @@ class ActNorm(Transform):
             raise TypeError("Number of features must be a positive integer.")
         super().__init__()
 
-        self.initialized = False
+        self.register_buffer("initialized", torch.zeros(1, dtype=torch.bool))
         self.log_scale = nn.Parameter(torch.zeros(features))
         self.shift = nn.Parameter(torch.zeros(features))
 
@@ -216,4 +216,4 @@ class ActNorm(Transform):
             self.log_scale.data = -torch.log(std)
             self.shift.data = -mu
 
-        self.initialized = True
+        self.initialized[0] = 1

--- a/nflows/transforms/normalization.py
+++ b/nflows/transforms/normalization.py
@@ -154,7 +154,7 @@ class ActNorm(Transform):
             raise TypeError("Number of features must be a positive integer.")
         super().__init__()
 
-        self.register_buffer("initialized", torch.zeros(1, dtype=torch.bool))
+        self.register_buffer("initialized", torch.tensor(False, dtype=torch.bool))
         self.log_scale = nn.Parameter(torch.zeros(features))
         self.shift = nn.Parameter(torch.zeros(features))
 
@@ -215,5 +215,4 @@ class ActNorm(Transform):
             mu = (inputs / std).mean(dim=0)
             self.log_scale.data = -torch.log(std)
             self.shift.data = -mu
-
-        self.initialized[0] = 1
+            self.initialized.data = torch.tensor(True, dtype=torch.bool)

--- a/tests/transforms/normalization_test.py
+++ b/tests/transforms/normalization_test.py
@@ -120,6 +120,26 @@ class ActNormTest(TransformTest):
                 self.eps = 1e-6
                 self.assert_forward_inverse_are_consistent(transform, inputs)
 
+    def test_save_load(self):
+        batch_size = 50
+        for shape in [(100,), (32, 8, 8)]:
+            with self.subTest(shape=shape):
+                inputs = torch.randn(batch_size, *shape)  # Test data
+
+                transform = norm.ActNorm(shape[0])
+                outputs1, logabsdet1 = transform.forward(inputs)  # One forward pass to initialize
+                state_dict = transform.state_dict()  # Save state dict
+
+                transform = norm.ActNorm(shape[0])  # Re-initialize transform
+                transform.load_state_dict(state_dict)
+                noise = torch.randn(batch_size, *shape)  # New data to confuse the initialization
+                _ = transform.forward(noise)  # Try to confuse the network
+                outputs2, logabsdet2 = transform.forward(inputs)  # Evaluate on test data
+
+                self.eps = 1e-6
+                self.assertEqual(outputs1, outputs2)
+                self.assertEqual(logabsdet1, logabsdet2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/transforms/normalization_test.py
+++ b/tests/transforms/normalization_test.py
@@ -126,17 +126,19 @@ class ActNormTest(TransformTest):
             with self.subTest(shape=shape):
                 inputs = torch.randn(batch_size, *shape)  # Test data
 
-                transform = norm.ActNorm(shape[0])
-                outputs1, logabsdet1 = transform.forward(inputs)  # One forward pass to initialize
-                state_dict = transform.state_dict()  # Save state dict
+                transform1 = norm.ActNorm(shape[0])
+                outputs1, logabsdet1 = transform1.forward(inputs)  # One forward pass to initialize
+                state_dict = transform1.state_dict()  # Save state dict
 
-                transform = norm.ActNorm(shape[0])  # Re-initialize transform
-                transform.load_state_dict(state_dict)
+                transform2 = norm.ActNorm(shape[0])  # Re-initialize transform
+                transform2.load_state_dict(state_dict)
                 noise = torch.randn(batch_size, *shape)  # New data to confuse the initialization
-                _ = transform.forward(noise)  # Try to confuse the network
-                outputs2, logabsdet2 = transform.forward(inputs)  # Evaluate on test data
+                _ = transform2.forward(noise)  # Try to confuse the transform
+                outputs2, logabsdet2 = transform2.forward(inputs)  # Evaluate on test data
 
                 self.eps = 1e-6
+                self.assertEqual(transform1.log_scale, transform2.log_scale)
+                self.assertEqual(transform1.shift, transform2.shift)
                 self.assertEqual(outputs1, outputs2)
                 self.assertEqual(logabsdet1, logabsdet2)
 


### PR DESCRIPTION
This PR changes the behavior of `ActNorm` by registering the flag `initialized` as a buffer. This fixes #4: saving a state dict, loading it, and resuming training will no longer re-initialize the ActNorm layers.

This PR also adds a test for the consistency of ActNorm layers when saving and loading a state dict.

*Warning*: this PR breaks backwards compatibility with old saved state dicts (or at least will require some workaround when loading an old state dict).