### PR TITLE
Fix memory leak in batch norm

### DIFF
--- a/nflows/transforms/normalization.py
+++ b/nflows/transforms/normalization.py
@@ -103,8 +103,8 @@ class BatchNorm(Transform):
 
         if self.training:
             mean, var = inputs.mean(0), inputs.var(0)
-            self.running_mean.mul_(1 - self.momentum).add_(mean * self.momentum)
-            self.running_var.mul_(1 - self.momentum).add_(var * self.momentum)
+            self.running_mean.mul_(1 - self.momentum).add_(mean.detach() * self.momentum)
+            self.running_var.mul_(1 - self.momentum).add_(var.detach() * self.momentum)
         else:
             mean, var = self.running_mean, self.running_var
 


### PR DESCRIPTION
This pull request fixes the memory leak described in the linked issue: https://github.com/bayesiains/nflows/issues/10

The fix is simply to detach the graph prior to computing the running meaning and variance for batch norm.