### PR TITLE
Full-rank orthogonal transforms with settable parameter matrix

### DIFF
--- a/nflows/transforms/orthogonal.py
+++ b/nflows/transforms/orthogonal.py
@@ -2,7 +2,7 @@
 
 import torch
 from torch import nn
-
+import torch.nn.functional as F
 from nflows.transforms.base import Transform
 import nflows.utils.typechecks as check
 
@@ -108,3 +108,257 @@ class HouseholderSequence(Transform):
         identity = torch.eye(self.features, self.features)
         outputs, _ = self.inverse(identity)
         return outputs
+
+
+def simplified_hh_vector_product(u, a):
+    '''
+    Apply Householder Transformation to Vector or Matrix, given reflection Vector
+    Args:
+        u (torch.Tensor): Householder Reflection Vector of shape (n)
+        a (torch.Tensor): Vector of Shape (n) or Matrix of shape (n, *)
+    Returns:
+        Transformed Vector or Matrix of same shape as a
+    '''
+    if len(a.shape) == 1:
+        a = a.unsqueeze(-1)
+    n2 = torch.dot(u, u).sqrt()
+    if (n2.item() == 0.0):
+        return a
+    un = u / n2
+    return a - (2.0 * un.unsqueeze(0).mm(a)) * un.unsqueeze(-1)
+
+
+def create_hh_matrix(v):
+    '''
+    Create Householder Matrix from Reflection Vector
+    :param v: Reflection Vector of shape (n)
+    :return: Householder Matrix of shape (n,n)
+    '''
+    H = torch.eye(v.shape[0])
+    n2sq = torch.dot(v, v)
+    if n2sq == 0.0:
+        return H
+    H -= (2 / n2sq) * torch.mm(v.unsqueeze(-1), v.unsqueeze(0))
+    return H
+
+
+def householder_qr(A):
+    '''
+    Perform QR decomposition based on a constructive inverse of Proof A.1 of Paper
+    Zhang: Stabilizing Gradients for Deep Neural Networks via Efficient SVD Parameterization
+    see https://arxiv.org/pdf/1803.09327.pdf
+
+    This algorithm ensures that the resulting R has a nonnegative diagonal,
+    and we get the proper reflection vectors.
+
+    Args:
+        A (torch.Tensor): Matrix to factorize
+    Returns:
+        Q (torch.Tensor): Orthogonal Matrix Q
+        R (torch.Tensor): Upper triangular matrix with positive diagonal
+        U (torch.Tensor): Upper Triangular Matrix of Reflection Vectors
+    '''
+
+    def _make_householder(a):
+        v = a.clone()  # - np.linalg.norm_type(a)(a[0] + np.copysign(np.linalg.norm_type(a), a[0]))
+        v[0] -= a.norm(2)
+        return v
+
+    m, n = A.shape
+    Q = torch.eye(m)
+    U = torch.eye(m)
+    for i in range(n - (m == n)):
+        U[i, i:] = _make_householder(A[i:, i])
+        H = create_hh_matrix(U[i, :])
+        Q = torch.mm(Q, H)
+        A = simplified_hh_vector_product(U[i, :], A)
+
+    # Exception for n=1 as in proof
+    # except that we apply it to the last index, instead of the first.
+    if m == n:
+        i = n - 1
+        if A[i, i] > 0.0:
+            U[i, i] = 0.0
+        else:
+            U[i, i] = 1.0
+        H = create_hh_matrix(U[i, :])
+        Q = torch.mm(Q, H)
+        R = torch.mm(H, A)
+    else:
+        R = A
+    return Q, R, U
+
+
+class FullOrthogonalTransform(Transform):
+    '''
+    This module implements an efficiently parameterized & quickly invertible Orthogonal Linear Transformation
+    based on a product of Householder Matrices (or Reflectors)
+
+    The transform is equivalent to multiplication with an orthogonal matrix
+    (accessible as commputed property W of this module ) and optional subsequent addition of a bias term.
+
+    The image of the product of these reflectors is the entire manifold of orthogonal matrices,
+    so that efficient backprop is possible while maintaining the Orthogonality Property of the Transform.
+
+    It is possible to assign an orthogonal matrix to the W property, which will then be decomposed into
+    the corresponding householder reflections via qr decomposition.
+    '''
+
+    weight: nn.Parameter
+    bias: nn.Parameter
+    n: int
+    m: int
+    h1: float
+
+    def __init__(self, features: int, bias=False):
+        """
+        Orthogonal Linear Transformation, efficiently parameterized & invertible.
+
+        :param features: Dimensionality of Transform ( equivalent orthogonal Matrix W will have dimensions features x features )
+        :param bias: Whether to add / subtract a bias term. Defaults to false
+        """
+        super().__init__()
+        self.h1 = 1.0  # Constant for lowest right coefficient of last householder reflection matrix, has to be .0 or 1.0. Only used if features==num_transforms
+        self.n = features
+        self.m = features # number of householder reflections. Fixed at number of features in this class.
+        # Full parameter matrix, which needs to be constrained further to a lower triangular form (see property U below)
+        self.weight = nn.Parameter(torch.randn((features, self.m)) * 0.01)
+        if bias:
+            self.bias = nn.Parameter(torch.randn((1, features)) * 0.01)
+        else:
+            self.register_parameter('bias', None)
+        self.register_buffer('_eye_n', torch.eye(self.n, requires_grad=False))
+
+    @property
+    def U(self):
+        '''
+        Constrained parameter Matrix U.
+
+        This is weight constrained to lower triangular, with U[-1,-1] set to h1 if n==m
+        see Mhammedi: Efficient Orthogonal Parametrisation of Recurrent Neural Networks Using Householder Reflections
+        '''
+        U = self.weight.triu()
+        if self.n == self.m:
+            U.data[-1, -1] = self.h1
+        return U
+
+    @property
+    def W(self):
+        '''
+        Orthogonal Matrix W, computed on-the-fly, representing the forward transformation without bias term.
+
+        Returns:
+            A Tensor of shape [D, D].
+        '''
+        return self._forward(self._eye_n)
+
+    def matrix(self):
+        """Returns the orthogonal matrix that is equivalent to the inverse transform.
+
+        Returns:
+            A Tensor of shape [D, D].
+        """
+        return self._inverse(self._eye_n)
+
+    @W.setter
+    def W(self, new_W):
+        """
+        Assign a valid orthogonal matrix to this transformation. This matrix will be decomposed into a
+        sequence of Householder reflections.
+
+        This call will fail with an assertion error if the assigned matrix is not orthogonal,
+        or if n!=m in the constructor
+        :param new_W: Torch
+        """
+        # Check preconditions
+        with torch.no_grad():
+            assert (self.n == self.m)
+            assert (len(new_W.shape) == 2)
+            assert (self.n == new_W.shape[0])
+            assert (self.n == new_W.shape[1])
+            assert (torch.slogdet(new_W)[1].abs().item() < 1e-5)  # Simple check for orthogonality
+            Q, R, U = householder_qr(new_W.t())
+            self.weight.data.copy_(U)
+            self.h1 = U[-1, -1].item()
+
+    def _forward(self, x):
+        h = x.t().contiguous()
+        U = self.U
+        for i in reversed(range(self.m)):
+            h = simplified_hh_vector_product(U[i, :], h)
+
+        return h.t().contiguous()
+
+    def _inverse(self, x):
+        '''
+        Peforms inverted Orthogonal Transform of x
+        equivalent to self.W.t().matmul(x), but slightly more efficient
+
+        Args:
+            x ( torch.Tensor): Input tensor to transform
+        Returns:
+            Transformed tensor of same shape as x
+        '''
+        h = x.t().contiguous()
+        U = self.U
+        for i in range(self.m):
+            h = simplified_hh_vector_product(U[i, :], h)
+        return h.t().contiguous()
+
+    def forward(self, x, context=None):
+        logabsdet = torch.zeros(x.shape[0])
+        return self._forward(x), logabsdet
+
+    def inverse(self, x, context=None):
+        inverse = self._inverse(x)
+        logabsdet = torch.zeros(x.shape[0])
+        return inverse, logabsdet
+
+class FullOrthogonalTransform2D(FullOrthogonalTransform):
+    """
+    Full 1x1 convolution operation with an orthogonal matrix backed by a sequence of householder reflectors.
+    See class FullOrthogonalTransform for details.
+
+    Allows to manually set and retrieve weight matrix "W" and optional bias vector "bias"
+    """
+
+    def _forward_conv(self, x):
+        '''
+        Performs forward Orthogonal Transform of x as a pixelwise 2D convolution
+
+        Args:
+            x (torch.Tensor): Tensor to transform
+        Returns:
+            Transformed tensor of same shape as x
+        '''
+        W = self.W.view(self.n, self.n, 1, 1)
+        if self.bias is not None:
+            bias = self.bias.squeeze()
+        else:
+            bias = None
+        return F.conv2d(x, W, bias, (1, 1), (0, 0), (1, 1), 1)
+
+    def _inverse_conv(self, x):
+        '''
+        Peforms inverted Orthogonal Transform of x
+        equivalent to self.W.t().matmul(x), but slightly more efficient
+        Args:
+            x (torch.Tensor): Input Tensor to be transformed
+        Returns:
+            Transformed tensor of same shape as x
+        '''
+        Wt = self.W.t().view(self.n, self.n, 1, 1)
+        if self.bias is not None:
+            bias = self.bias.view(1, self.bias.shape[1], 1, 1).contiguous()
+            return F.conv2d(x - bias, Wt, None, (1, 1), (0, 0), (1, 1), 1)
+        else:
+            return F.conv2d(x, Wt, None, (1, 1), (0, 0), (1, 1), 1)
+
+    def forward(self, x, context=None):
+        logabsdet = torch.zeros(x.shape[0])
+        return self._forward_conv(x), logabsdet
+
+    def inverse(self, x, context=None):
+        logabsdet = torch.zeros(x.shape[0])
+        return self._inverse_conv(x), logabsdet
+

--- a/tests/transforms/nonlinearities_test.py
+++ b/tests/transforms/nonlinearities_test.py
@@ -108,6 +108,10 @@ class NonlinearitiesTest(TransformTest):
             nl.Sigmoid(),
             nl.Logit(),
             nl.CompositeCDFTransform(nl.Sigmoid(), standard.IdentityTransform()),
+            nl.HiLU(param_shape=[1] + [1, 1, 1]),
+            nl.HiLU(param_shape=[1]+[ shape[0], 1, 1]),
+            nl.HiLU(param_shape=[1] + [shape[0], shape[1], 1]),
+            nl.HiLU(param_shape=[1] + [shape[0], shape[1], shape[2]]),
         ]
         for transform in transforms:
             with self.subTest(transform=transform):
@@ -126,6 +130,10 @@ class NonlinearitiesTest(TransformTest):
             nl.Sigmoid(),
             nl.Logit(),
             nl.CompositeCDFTransform(nl.Sigmoid(), standard.IdentityTransform()),
+            nl.HiLU(param_shape=[1] + [1, 1, 1]),
+            nl.HiLU(param_shape=[1] + [shape[0], 1, 1]),
+            nl.HiLU(param_shape=[1] + [shape[0], shape[1], 1]),
+            nl.HiLU(param_shape=[1] + [shape[0], shape[1], shape[2]]),
         ]
         for transform in transforms:
             with self.subTest(transform=transform):
@@ -144,6 +152,10 @@ class NonlinearitiesTest(TransformTest):
             nl.Sigmoid(),
             nl.Logit(),
             nl.CompositeCDFTransform(nl.Sigmoid(), standard.IdentityTransform()),
+            nl.HiLU(param_shape=[1, 1, 1, 1], init_log_range=2.0),
+            nl.HiLU(param_shape=[1] + [shape[0], 1, 1], init_log_range=2.0),
+            nl.HiLU(param_shape=[1] + [shape[0], shape[1], 1], init_log_range=2.0),
+            nl.HiLU(param_shape=[1] + [shape[0], shape[1], shape[2]], init_log_range=2.0),
         ]
         self.eps = 1e-3
         for transform in transforms:

--- a/tests/transforms/orthogonal_test.py
+++ b/tests/transforms/orthogonal_test.py
@@ -3,7 +3,8 @@
 import unittest
 
 import torch
-
+import numpy as np
+import math
 from nflows.transforms import orthogonal
 from nflows.utils import torchutils
 from tests.transforms.transform_test import TransformTest
@@ -82,6 +83,173 @@ class HouseholderSequenceTest(TransformTest):
             with self.subTest(transform=transform):
                 self.assert_forward_inverse_are_consistent(transform, inputs)
 
+
+    def test_forward_full_orthogonal(self):
+        features = 100
+        batch_size = 50
+        transform = orthogonal.FullOrthogonalTransform(
+            features=features
+        )
+        matrix = transform.matrix()
+        inputs = torch.randn(batch_size, features)
+        outputs, logabsdet = transform(inputs)
+        self.assert_tensor_is_good(outputs, [batch_size, features])
+        self.assert_tensor_is_good(logabsdet, [batch_size])
+        self.eps = 1e-5
+        self.assertEqual(outputs, inputs @ matrix.t())
+        self.assertEqual(outputs, inputs @ transform.W)
+        self.assertEqual(
+            logabsdet, torchutils.logabsdet(matrix) * torch.ones(batch_size)
+        )
+        self.assert_forward_inverse_are_consistent(transform, inputs)
+
+    def test_inverse_full_orthogonal(self):
+        features = 100
+        batch_size = 50
+        transform = orthogonal.FullOrthogonalTransform(
+            features=features
+        )
+        matrix = transform.matrix()
+        inputs = torch.randn(batch_size, features)
+        outputs, logabsdet = transform.inverse(inputs)
+        self.assert_tensor_is_good(outputs, [batch_size, features])
+        self.assert_tensor_is_good(logabsdet, [batch_size])
+        self.eps = 1e-5
+        self.assertEqual(outputs, inputs @ matrix)
+        self.assertEqual(
+            logabsdet, torchutils.logabsdet(matrix) * torch.ones(batch_size)
+        )
+        self.assert_forward_inverse_are_consistent(transform, inputs)
+
+
+    def verify_qr_of_orthogonal_matrix(self, U, n):
+        Q, R, U2 = orthogonal.householder_qr(U)
+        diffr = (R - torch.eye(n)).abs().max().item()
+        # When doing *this* QR decomposition of an Orthogonal Matrix, we expect resulting R to be the identity matrix
+        # as in the proof
+        self.assertTrue(diffr < 2e-5)
+        diffi = (R - torch.eye(n)).abs().max().item()
+        self.assertTrue(diffi < 1e-5)
+        diffq = (Q - U).abs().max().item()
+        self.assertTrue(diffq < 1e-5)
+        # Now make sure that the Matrix Q is actually the product of our householder matrices
+        Q2 = torch.eye(n)
+        for i in range(U2.shape[0]):
+            Q2 = torch.mm(Q2, orthogonal.create_hh_matrix(U2[i, :]))
+        diffq2 = (Q - Q2).abs().max().item()
+        self.assertTrue(diffq2 < 1e-5)
+        # Now make sure that the Matrix Q can be constructed using the simplified householder transformation
+        # Using vector products (note that the order needs to be inversed)
+        Q3 = torch.eye(n)
+        for i in reversed(range(U2.shape[0])):
+            Q3 = orthogonal.simplified_hh_vector_product(U2[i, :], Q3)
+        diffq3 = (Q - Q3).abs().max().item()
+        self.assertTrue(diffq3 < 1e-5)
+
+    def test_householder_qr(self):
+        # Test our implementation of the QR Decomposition of Orthogonal Matrices
+        # into Householder Reflection Vecors
+
+        # First, to check some boundary conditions, we try some trivial orthogonal matrices
+        self.verify_qr_of_orthogonal_matrix(torch.eye(1), 1)
+        self.verify_qr_of_orthogonal_matrix(torch.eye(2), 2)
+        self.verify_qr_of_orthogonal_matrix(torch.eye(3), 3)
+        self.verify_qr_of_orthogonal_matrix(torch.FloatTensor([[0, 1], [1, 0]]), 2)
+        self.verify_qr_of_orthogonal_matrix(torch.FloatTensor([[3, 4], [-4, 3]]) * 0.2, 2)
+
+        # Now we try a lot of rotation matrices
+        for alpha in np.linspace(0.0, 2.0, 36):
+            a = alpha * math.pi
+            rmatrix = torch.FloatTensor([[math.cos(a), -math.sin(a)], [math.sin(a), math.cos(a)]])
+            self.verify_qr_of_orthogonal_matrix(rmatrix, 2)
+
+        # And now a lot of random 20 dimensional matrices
+        for k in range(10):
+            n = 20
+            A = torch.randn((n, n))
+            U, S, V = torch.svd(A)
+            # Now U and V are random orthogonal Matrices
+            self.verify_qr_of_orthogonal_matrix(U, n)
+            self.verify_qr_of_orthogonal_matrix(V, n)
+
+
+    def test_orthogonal_transform_W_setter(self):
+        a = torch.randn((4, 4))
+        u, s, v = torch.svd(a)
+        ot = orthogonal.FullOrthogonalTransform(4, bias=False)
+        ot.W = u  # This uses a setter method
+
+        # Check that we have actually set W, and that the reconstruction into property W works
+        wr = ot.W
+        self.assertTrue((u - wr).abs().max().item() < 1e-5)
+
+        # Check that forward really applies the orthogonal transformation we specified
+        wr2, logabsdet = ot.forward(torch.eye(4))
+        self.assertTrue((u - wr2).abs().max().item() < 1e-5)
+
+        # Check that forward really applies the orthogonal transformation we specified
+        wr3_t, logabsdet = ot.inverse(torch.eye(4))
+        wr3 = wr3_t.t()
+        self.assertTrue((u - wr3).abs().max().item() < 1e-5)
+
+    def test_orthogonal_transform(self):
+        n = 20
+        for bias in [True, False]:
+            for i in range(10):
+                a = torch.randn((10, n))
+                ot = orthogonal.FullOrthogonalTransform(n, bias=bias)
+                b, logabsdet = ot.forward(a)
+                self.assertFalse(np.all(np.isclose(a.detach().numpy(), b.detach().numpy(), atol=1e-5)))
+                ar, logabsdet = ot.inverse(b)
+                self.assertTrue(np.all(np.isclose(a.detach().numpy(), ar.detach().numpy(), atol=1e-5)))
+                self.assertAlmostEqual(torch.slogdet(ot.W)[1].item(), 0.0,
+                                       delta=1e-5)  # Determinant of Orthogonal Matrix needs to be close to 1 or -1
+                W = ot.W
+                Wt = ot.W.t()
+                Winv = torch.inverse(W)
+                self.assertTrue(np.all(np.isclose(Wt.detach().numpy(), Winv.detach().numpy(), atol=1e-5)))
+            for i in range(10):
+                a = torch.randn((10, n))
+                ot = orthogonal.FullOrthogonalTransform(n, bias=bias)
+                b, logabsdet = ot.inverse(a)
+                self.assertFalse(np.all(np.isclose(a.detach().numpy(), b.detach().numpy(), atol=1e-5)))
+                ar, logabsdet = ot.forward(b)
+                self.assertTrue(np.all(np.isclose(a.detach().numpy(), ar.detach().numpy(), atol=1e-5)))
+                self.assertAlmostEqual(torch.slogdet(ot.W)[1].item(), 0.0,
+                                       delta=1e-5)  # Determinant of Orthogonal Matrix needs to be close to 1 or -1
+                W = ot.W
+                Wt = ot.W.t()
+                Winv = torch.inverse(W)
+                self.assertTrue(np.all(np.isclose(Wt.detach().numpy(), Winv.detach().numpy(), atol=1e-6)))
+
+    def test_orthogonal_transform2d(self):
+        for bias in [True, False]:
+            for i in range(10):
+                a = torch.randn((10, 5, 10, 10))
+                ot = orthogonal.FullOrthogonalTransform2D(5, bias=bias)
+                b, logabsdet = ot.forward(a)
+                self.assertFalse(np.all(np.isclose(a.detach().numpy(), b.detach().numpy(), atol=1e-6)))
+                ar, logabsdet = ot.inverse(b)
+                self.assertTrue(np.all(np.isclose(a.detach().numpy(), ar.detach().numpy(), atol=1e-5)))
+                self.assertAlmostEqual(torch.slogdet(ot.W)[1].item(), 0.0,
+                                       delta=2e-6)  # Determinant of Orthogonal Matrix needs to be close to 1 or -1
+                W = ot.W
+                Wt = ot.W.t()
+                Winv = torch.inverse(W)
+                self.assertTrue(np.all(np.isclose(Wt.detach().numpy(), Winv.detach().numpy(), atol=1e-5)))
+            for i in range(10):
+                a = torch.randn((10, 5, 10, 10))
+                ot = orthogonal.FullOrthogonalTransform2D(5, bias=bias)
+                b, logabsdet = ot.inverse(a)
+                self.assertFalse(np.all(np.isclose(a.detach().numpy(), b.detach().numpy(), atol=1e-5)))
+                ar, logabsdet = ot.forward(b)
+                self.assertTrue(np.all(np.isclose(a.detach().numpy(), ar.detach().numpy(), atol=1e-5)))
+                self.assertAlmostEqual(torch.slogdet(ot.W)[1].item(), 0.0,
+                                       delta=2e-6)  # Determinant of Orthogonal Matrix needs to be close to 1 or -1
+                W = ot.W
+                Wt = ot.W.t()
+                Winv= torch.inverse(W)
+                self.assertTrue(np.all(np.isclose(Wt.detach().numpy(), Winv.detach().numpy(), atol=3e-6)))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The difference to your existing implementation ( HouseholderSequence ) is, that this implementation allows to reverse engineer a sequence of householder reflections given an orthogonal matrix. This allows to use SVD to decompose any invertible matrix into a parametrization that works in both directions, and can also be used for pixelwise convolutions. 

This is a port from library similar to nflows that I have been working on for a while (still unreleased). Given that nflows seems to be more feature complete compared to my library, I decided to port the most useful code and ideas over to NFlows. This is the first bit of code I would like to port over, and a key component for some novel architectures I am working on.

If possible, I would like to become a regular contributor to the nflows library. I am a Senior Machine Learning engineer in the Deep Learning team of the Volkswagen Data Lab Munich, this project is something I do in my spare time.