### PR TITLE
Added option for inverse autoregressive flows & corresponding unit test

### DIFF
--- a/tests/transforms/autoregressive_test.py
+++ b/tests/transforms/autoregressive_test.py
@@ -21,28 +21,18 @@ class MaskedAffineAutoregressiveTransformTest(TransformTest):
             with self.subTest(
                 use_residual_blocks=use_residual_blocks, random_mask=random_mask
             ):
-                transform = autoregressive.MaskedAffineAutoregressiveTransform(
-                    features=features,
-                    hidden_features=30,
-                    num_blocks=5,
-                    use_residual_blocks=use_residual_blocks,
-                    random_mask=random_mask,
-                )
-                outputs, logabsdet = transform(inputs)
-                self.assert_tensor_is_good(outputs, [batch_size, features])
-                self.assert_tensor_is_good(logabsdet, [batch_size])
-
-                transform = autoregressive.MaskedAffineAutoregressiveTransform(
-                    features=features,
-                    hidden_features=30,
-                    num_blocks=5,
-                    use_residual_blocks=use_residual_blocks,
-                    random_mask=random_mask,
-                    fast_direction='inverse',
-                )
-                outputs, logabsdet = transform(inputs)
-                self.assert_tensor_is_good(outputs, [batch_size, features])
-                self.assert_tensor_is_good(logabsdet, [batch_size])
+                for fast_direction in ['forward', 'inverse']:
+                    transform = autoregressive.MaskedAffineAutoregressiveTransform(
+                        features=features,
+                        hidden_features=30,
+                        num_blocks=5,
+                        use_residual_blocks=use_residual_blocks,
+                        random_mask=random_mask,
+                        fast_direction=fast_direction,
+                    )
+                    outputs, logabsdet = transform(inputs)
+                    self.assert_tensor_is_good(outputs, [batch_size, features])
+                    self.assert_tensor_is_good(logabsdet, [batch_size])
 
     def test_inverse(self):
         batch_size = 10
@@ -56,28 +46,18 @@ class MaskedAffineAutoregressiveTransformTest(TransformTest):
             with self.subTest(
                 use_residual_blocks=use_residual_blocks, random_mask=random_mask
             ):
-                transform = autoregressive.MaskedAffineAutoregressiveTransform(
-                    features=features,
-                    hidden_features=30,
-                    num_blocks=5,
-                    use_residual_blocks=use_residual_blocks,
-                    random_mask=random_mask,
-                )
-                outputs, logabsdet = transform.inverse(inputs)
-                self.assert_tensor_is_good(outputs, [batch_size, features])
-                self.assert_tensor_is_good(logabsdet, [batch_size])
-
-                transform = autoregressive.MaskedAffineAutoregressiveTransform(
-                    features=features,
-                    hidden_features=30,
-                    num_blocks=5,
-                    use_residual_blocks=use_residual_blocks,
-                    random_mask=random_mask,
-                    fast_direction='inverse',
-                )
-                outputs, logabsdet = transform.inverse(inputs)
-                self.assert_tensor_is_good(outputs, [batch_size, features])
-                self.assert_tensor_is_good(logabsdet, [batch_size])
+                for fast_direction in ['forward', 'inverse']:
+                    transform = autoregressive.MaskedAffineAutoregressiveTransform(
+                        features=features,
+                        hidden_features=30,
+                        num_blocks=5,
+                        use_residual_blocks=use_residual_blocks,
+                        random_mask=random_mask,
+                        fast_direction=fast_direction
+                    )
+                    outputs, logabsdet = transform.inverse(inputs)
+                    self.assert_tensor_is_good(outputs, [batch_size, features])
+                    self.assert_tensor_is_good(logabsdet, [batch_size])
 
     def test_forward_inverse_are_consistent(self):
         batch_size = 10
@@ -92,25 +72,16 @@ class MaskedAffineAutoregressiveTransformTest(TransformTest):
             with self.subTest(
                 use_residual_blocks=use_residual_blocks, random_mask=random_mask
             ):
-                transform = autoregressive.MaskedAffineAutoregressiveTransform(
-                    features=features,
-                    hidden_features=30,
-                    num_blocks=5,
-                    use_residual_blocks=use_residual_blocks,
-                    random_mask=random_mask,
-                )
-                self.assert_forward_inverse_are_consistent(transform, inputs)
-
-                transform = autoregressive.MaskedAffineAutoregressiveTransform(
-                    features=features,
-                    hidden_features=30,
-                    num_blocks=5,
-                    use_residual_blocks=use_residual_blocks,
-                    random_mask=random_mask,
-                    fast_direction='inverse',
-                )
-                self.assert_forward_inverse_are_consistent(transform, inputs)
-
+                for fast_direction in ['forward', 'inverse']:
+                    transform = autoregressive.MaskedAffineAutoregressiveTransform(
+                        features=features,
+                        hidden_features=30,
+                        num_blocks=5,
+                        use_residual_blocks=use_residual_blocks,
+                        random_mask=random_mask,
+                        fast_direction=fast_direction
+                    )
+                    self.assert_forward_inverse_are_consistent(transform, inputs)
 
 class MaskedPiecewiseLinearAutoregressiveTranformTest(TransformTest):
     def test_forward_inverse_are_consistent(self):
@@ -119,27 +90,15 @@ class MaskedPiecewiseLinearAutoregressiveTranformTest(TransformTest):
         inputs = torch.rand(batch_size, features)
         self.eps = 1e-3
 
-        transform = autoregressive.MaskedPiecewiseLinearAutoregressiveTransform(
-            num_bins=10,
-            features=features,
-            hidden_features=30,
-            num_blocks=5,
-            use_residual_blocks=True,
-        )
-
-        self.assert_forward_inverse_are_consistent(transform, inputs)
-
-        transform = autoregressive.MaskedPiecewiseLinearAutoregressiveTransform(
-            num_bins=10,
-            features=features,
-            hidden_features=30,
-            num_blocks=5,
-            use_residual_blocks=True,
-            fast_direction='inverse',
-        )
-
-        self.assert_forward_inverse_are_consistent(transform, inputs)
-
+        for fast_direction in ['forward', 'inverse']:
+            transform = autoregressive.MaskedPiecewiseLinearAutoregressiveTransform(
+                num_bins=10,
+                features=features,
+                hidden_features=30,
+                num_blocks=5,
+                use_residual_blocks=True,
+            )
+            self.assert_forward_inverse_are_consistent(transform, inputs)
 
 class MaskedPiecewiseQuadraticAutoregressiveTranformTest(TransformTest):
     def test_forward_inverse_are_consistent(self):
@@ -148,27 +107,15 @@ class MaskedPiecewiseQuadraticAutoregressiveTranformTest(TransformTest):
         inputs = torch.rand(batch_size, features)
         self.eps = 1e-4
 
-        transform = autoregressive.MaskedPiecewiseQuadraticAutoregressiveTransform(
-            num_bins=10,
-            features=features,
-            hidden_features=30,
-            num_blocks=5,
-            use_residual_blocks=True,
-        )
-
-        self.assert_forward_inverse_are_consistent(transform, inputs)
-
-        transform = autoregressive.MaskedPiecewiseQuadraticAutoregressiveTransform(
-            num_bins=10,
-            features=features,
-            hidden_features=30,
-            num_blocks=5,
-            use_residual_blocks=True,
-            fast_direction='inverse',
-        )
-
-        self.assert_forward_inverse_are_consistent(transform, inputs)
-
+        for fast_direction in ['forward', 'inverse']:
+            transform = autoregressive.MaskedPiecewiseQuadraticAutoregressiveTransform(
+                num_bins=10,
+                features=features,
+                hidden_features=30,
+                num_blocks=5,
+                use_residual_blocks=True,
+            )
+            self.assert_forward_inverse_are_consistent(transform, inputs)
 
 class MaskedPiecewiseCubicAutoregressiveTranformTest(TransformTest):
     def test_forward_inverse_are_consistent(self):
@@ -177,27 +124,15 @@ class MaskedPiecewiseCubicAutoregressiveTranformTest(TransformTest):
         inputs = torch.rand(batch_size, features)
         self.eps = 1e-3
 
-        transform = autoregressive.MaskedPiecewiseCubicAutoregressiveTransform(
-            num_bins=10,
-            features=features,
-            hidden_features=30,
-            num_blocks=5,
-            use_residual_blocks=True,
-        )
-
-        self.assert_forward_inverse_are_consistent(transform, inputs)
-
-        transform = autoregressive.MaskedPiecewiseCubicAutoregressiveTransform(
-            num_bins=10,
-            features=features,
-            hidden_features=30,
-            num_blocks=5,
-            use_residual_blocks=True,
-            fast_direction='inverse',
-        )
-
-        self.assert_forward_inverse_are_consistent(transform, inputs)
-
+        for fast_direction in ['forward', 'inverse']:
+            transform = autoregressive.MaskedPiecewiseCubicAutoregressiveTransform(
+                num_bins=10,
+                features=features,
+                hidden_features=30,
+                num_blocks=5,
+                use_residual_blocks=True,
+            )
+            self.assert_forward_inverse_are_consistent(transform, inputs)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/transforms/autoregressive_test.py
+++ b/tests/transforms/autoregressive_test.py
@@ -32,6 +32,18 @@ class MaskedAffineAutoregressiveTransformTest(TransformTest):
                 self.assert_tensor_is_good(outputs, [batch_size, features])
                 self.assert_tensor_is_good(logabsdet, [batch_size])
 
+                transform = autoregressive.MaskedAffineAutoregressiveTransform(
+                    features=features,
+                    hidden_features=30,
+                    num_blocks=5,
+                    use_residual_blocks=use_residual_blocks,
+                    random_mask=random_mask,
+                    fast_direction='inverse',
+                )
+                outputs, logabsdet = transform(inputs)
+                self.assert_tensor_is_good(outputs, [batch_size, features])
+                self.assert_tensor_is_good(logabsdet, [batch_size])
+
     def test_inverse(self):
         batch_size = 10
         features = 20
@@ -50,6 +62,18 @@ class MaskedAffineAutoregressiveTransformTest(TransformTest):
                     num_blocks=5,
                     use_residual_blocks=use_residual_blocks,
                     random_mask=random_mask,
+                )
+                outputs, logabsdet = transform.inverse(inputs)
+                self.assert_tensor_is_good(outputs, [batch_size, features])
+                self.assert_tensor_is_good(logabsdet, [batch_size])
+
+                transform = autoregressive.MaskedAffineAutoregressiveTransform(
+                    features=features,
+                    hidden_features=30,
+                    num_blocks=5,
+                    use_residual_blocks=use_residual_blocks,
+                    random_mask=random_mask,
+                    fast_direction='inverse',
                 )
                 outputs, logabsdet = transform.inverse(inputs)
                 self.assert_tensor_is_good(outputs, [batch_size, features])
@@ -77,6 +101,16 @@ class MaskedAffineAutoregressiveTransformTest(TransformTest):
                 )
                 self.assert_forward_inverse_are_consistent(transform, inputs)
 
+                transform = autoregressive.MaskedAffineAutoregressiveTransform(
+                    features=features,
+                    hidden_features=30,
+                    num_blocks=5,
+                    use_residual_blocks=use_residual_blocks,
+                    random_mask=random_mask,
+                    fast_direction='inverse',
+                )
+                self.assert_forward_inverse_are_consistent(transform, inputs)
+
 
 class MaskedPiecewiseLinearAutoregressiveTranformTest(TransformTest):
     def test_forward_inverse_are_consistent(self):
@@ -91,6 +125,17 @@ class MaskedPiecewiseLinearAutoregressiveTranformTest(TransformTest):
             hidden_features=30,
             num_blocks=5,
             use_residual_blocks=True,
+        )
+
+        self.assert_forward_inverse_are_consistent(transform, inputs)
+
+        transform = autoregressive.MaskedPiecewiseLinearAutoregressiveTransform(
+            num_bins=10,
+            features=features,
+            hidden_features=30,
+            num_blocks=5,
+            use_residual_blocks=True,
+            fast_direction='inverse',
         )
 
         self.assert_forward_inverse_are_consistent(transform, inputs)
@@ -113,6 +158,17 @@ class MaskedPiecewiseQuadraticAutoregressiveTranformTest(TransformTest):
 
         self.assert_forward_inverse_are_consistent(transform, inputs)
 
+        transform = autoregressive.MaskedPiecewiseQuadraticAutoregressiveTransform(
+            num_bins=10,
+            features=features,
+            hidden_features=30,
+            num_blocks=5,
+            use_residual_blocks=True,
+            fast_direction='inverse',
+        )
+
+        self.assert_forward_inverse_are_consistent(transform, inputs)
+
 
 class MaskedPiecewiseCubicAutoregressiveTranformTest(TransformTest):
     def test_forward_inverse_are_consistent(self):
@@ -127,6 +183,17 @@ class MaskedPiecewiseCubicAutoregressiveTranformTest(TransformTest):
             hidden_features=30,
             num_blocks=5,
             use_residual_blocks=True,
+        )
+
+        self.assert_forward_inverse_are_consistent(transform, inputs)
+
+        transform = autoregressive.MaskedPiecewiseCubicAutoregressiveTransform(
+            num_bins=10,
+            features=features,
+            hidden_features=30,
+            num_blocks=5,
+            use_residual_blocks=True,
+            fast_direction='inverse',
         )
 
         self.assert_forward_inverse_are_consistent(transform, inputs)


### PR DESCRIPTION
Hello,

I made some simple modifications to the autoregressive transform such that it also allows one to use the architecture set out in 1606.04934. That is, the original implementation is fast in the inference direction but slow in the sampling direction, but now you can choose which direction is fast. 

I actually started implementing this because I originally incorrectly assumed the prior implementation was slow in the inference direction, but now that I wrote it I figured it might as well go in. 

Cheers,
Rob