### PR TITLE
Sampling on gpu

### DIFF
--- a/nflows/distributions/normal.py
+++ b/nflows/distributions/normal.py
@@ -6,7 +6,6 @@ from torch import nn
 
 from nflows.distributions.base import Distribution
 from nflows.utils import torchutils
-from torch._C import dtype
 
 
 class StandardNormal(Distribution):

--- a/nflows/transforms/base.py
+++ b/nflows/transforms/base.py
@@ -45,7 +45,7 @@ class CompositeTransform(Transform):
     def _cascade(inputs, funcs, context):
         batch_size = inputs.shape[0]
         outputs = inputs
-        total_logabsdet = torch.zeros(batch_size)
+        total_logabsdet = torch.zeros(batch_size, device=inputs.device)
         for func in funcs:
             outputs, logabsdet = func(outputs, context)
             total_logabsdet += logabsdet

--- a/nflows/transforms/permutations.py
+++ b/nflows/transforms/permutations.py
@@ -35,7 +35,7 @@ class Permutation(Transform):
             )
         batch_size = inputs.shape[0]
         outputs = torch.index_select(inputs, dim, permutation)
-        logabsdet = torch.zeros(batch_size)
+        logabsdet = torch.zeros(batch_size, device=inputs.device)
         return outputs, logabsdet
 
     def forward(self, inputs, context=None):

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -14,7 +14,7 @@ class IdentityTransform(Transform):
 
     def forward(self, inputs: Tensor, context=Optional[Tensor]):
         batch_size = inputs.size(0)
-        logabsdet = torch.zeros(batch_size)
+        logabsdet = torch.zeros(batch_size, device=inputs.device)
         return inputs, logabsdet
 
     def inverse(self, inputs: Tensor, context=Optional[Tensor]):


### PR DESCRIPTION
Hi Artur, 
we have been working on training the density estimators in [sbi](https://github.com/mackelab/sbi) on a GPU. That worked just fine when globally setting the default tensor to `torch.cuda.FloatTensor`. We wanted to avoid this global setting and instead move the net and the training batches to the device manually during training (see https://github.com/mackelab/sbi/pull/331)
However, this resulted in problems in `nflows` (mainly CPU-cuda device mismatches). I tried to fix these problems with the two commits in this PR, following the discussion in https://github.com/bayesiains/nflows/pull/9.  

I am happy to discuss the changes and feel free to change them or fix it differently. 

Once this is fixed, `sbi` can depend on it via `pyknos`. 

Best, 
Jan