### PR TITLE
Added CUDA bug fix to the Sigmoid in the nonlinearities module

### DIFF
--- a/nflows/transforms/nonlinearities.py
+++ b/nflows/transforms/nonlinearities.py
@@ -126,7 +126,8 @@ class Sigmoid(Transform):
         if learn_temperature:
             self.temperature = nn.Parameter(torch.Tensor([temperature]))
         else:
-            self.temperature = torch.Tensor([temperature])
+            temperature = torch.Tensor([temperature])
+            self.register_buffer('temperature', temperature)
 
     def forward(self, inputs, context=None):
         inputs = self.temperature * inputs


### PR DESCRIPTION
When we are setting the "learn_temperature" to False, the temperature is not sent to the correct device when trying to train on the GPU. By registering the temperature as a buffer, the temperature constant can be sent to the correct device.