### PR TITLE
Allow scales >1.001 in AffineCouplingTransform (fixes #49)

### DIFF
--- a/nflows/transforms/coupling.py
+++ b/nflows/transforms/coupling.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 import torch
+from torch.nn.functional import softplus
 
 from nflows.transforms import splines
 from nflows.transforms.base import Transform
@@ -214,16 +215,17 @@ class AffineCouplingTransform(CouplingTransform):
     Reference:
     > L. Dinh et al., Density estimation using Real NVP, ICLR 2017.
 
-    The scale is a neural network output transformed by the supplied `scale_activation`
-    then clamped to the interval `scale_min` to `scale_max`.
-    For backwards compatibility, the default `scale_activation` is sigmoid, producing a scale between 0 and 1.
-    In many applications this should be changed -- e.g. to softplus or exponential -- to permit scales above 1.
+    The user should supply `scale_activation`, the final activation function in the neural network producing the scale tensor.
+    Two options are predefined in the class.
+    `DEFAULT_SCALE_ACTIVATION` preserves backwards compatibility but only produces scales <= 1.001.
+    `GENERAL_SCALE_ACTIVATION` produces scales <= 3, which is more useful in general applications.
     """
 
-    def __init__(self, mask, transform_net_create_fn, unconditional_transform=None, scale_activation=torch.sigmoid, scale_min=1e-3, scale_max=3.):
+    DEFAULT_SCALE_ACTIVATION = lambda x : torch.sigmoid(x + 2) + 1e-3
+    GENERAL_SCALE_ACTIVATION = lambda x : (softplus(x) + 1e-3).clamp(0, 3)
+
+    def __init__(self, mask, transform_net_create_fn, unconditional_transform=None, scale_activation=DEFAULT_SCALE_ACTIVATION):
         self.scale_activation = scale_activation
-        self.scale_min = scale_min
-        self.scale_max = scale_max
         super().__init__(mask, transform_net_create_fn, unconditional_transform)
 
     def _transform_dim_multiplier(self):
@@ -232,7 +234,7 @@ class AffineCouplingTransform(CouplingTransform):
     def _scale_and_shift(self, transform_params):
         unconstrained_scale = transform_params[:, self.num_transform_features:, ...]
         shift = transform_params[:, : self.num_transform_features, ...]
-        scale = self.scale_activation(unconstrained_scale).clamp(self.scale_min, self.scale_max)
+        scale = self.scale_activation(unconstrained_scale)
         return scale, shift
 
     def _coupling_transform_forward(self, inputs, transform_params):

--- a/tests/transforms/coupling_test.py
+++ b/tests/transforms/coupling_test.py
@@ -71,6 +71,18 @@ class AffineCouplingTransformTest(TransformTest):
             with self.subTest(shape=shape):
                 self.assert_forward_inverse_are_consistent(transform, inputs)
 
+    def test_scale_activation_has_an_effect(self):
+        for shape in self.shapes:
+            inputs = torch.randn(batch_size, *shape)
+            transform, mask = create_coupling_transform(
+                coupling.AffineCouplingTransform, shape
+            )
+            outputs_default, logabsdet_default = transform(inputs)
+            transform.scale_activation = coupling.AffineCouplingTransform.GENERAL_SCALE_ACTIVATION
+            outputs_general, logabsdet_general = transform(inputs)
+            with self.subTest(shape=shape):
+                self.assertNotEqual(outputs_default, outputs_general)
+                self.assertNotEqual(logabsdet_default, logabsdet_general)
 
 class AdditiveTransformTest(TransformTest):
     shapes = [[20], [2, 4, 4]]


### PR DESCRIPTION
I've run unit tests. On my first attempt there was one failure (see below) which didn't seem relevant to this change, and I couldn't reproduce this on rerunning the tests (i.e. on trying the unit tests again they all passed)

```
FAIL: test_forward_inverse_are_consistent (transforms.nonlinearities_test.TestPiecewiseCDF) (transform=PiecewiseLinearCDF())
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dennis/git/nflows/tests/transforms/nonlinearities_test.py", line 63, in test_forward_inverse_are_consistent
    self.assert_forward_inverse_are_consistent(transform, inputs)
  File "/home/dennis/git/nflows/tests/transforms/transform_test.py", line 25, in assert_forward_inverse_are_consistent
    self.assertEqual(logabsdet, torch.zeros(inputs.shape[:1]))
AssertionError: The tensors are different!

----------------------------------------------------------------------
```