### PR TITLE
Solve torch.triangular_solve deprecation warning

### DIFF
--- a/nflows/transforms/lu.py
+++ b/nflows/transforms/lu.py
@@ -77,10 +77,10 @@ class LULinear(Linear):
         """
         lower, upper = self._create_lower_upper()
         outputs = inputs - self.bias
-        outputs, _ = torch.linalg.solve_triangular(
+        outputs = torch.linalg.solve_triangular(
             outputs.t(), lower, upper=False, unitriangular=True
         )
-        outputs, _ = torch.linalg.solve_triangular(
+        outputs = torch.linalg.solve_triangular(
             outputs, upper, upper=True, unitriangular=False
         )
         outputs = outputs.t()
@@ -107,10 +107,10 @@ class LULinear(Linear):
         """
         lower, upper = self._create_lower_upper()
         identity = torch.eye(self.features, self.features)
-        lower_inverse, _ = torch.linalg.solve_triangular(
+        lower_inverse = torch.linalg.solve_triangular(
             identity, lower, upper=False, unitriangular=True
         )
-        weight_inverse, _ = torch.linalg.solve_triangular(
+        weight_inverse = torch.linalg.solve_triangular(
             lower_inverse, upper, upper=True, unitriangular=False
         )
         return weight_inverse

--- a/nflows/transforms/lu.py
+++ b/nflows/transforms/lu.py
@@ -78,10 +78,10 @@ class LULinear(Linear):
         lower, upper = self._create_lower_upper()
         outputs = inputs - self.bias
         outputs = torch.linalg.solve_triangular(
-            outputs.t(), lower, upper=False, unitriangular=True
+            lower, outputs.t(), upper=False, unitriangular=True
         )
         outputs = torch.linalg.solve_triangular(
-            outputs, upper, upper=True, unitriangular=False
+            upper, outputs, upper=True, unitriangular=False
         )
         outputs = outputs.t()
 
@@ -108,10 +108,10 @@ class LULinear(Linear):
         lower, upper = self._create_lower_upper()
         identity = torch.eye(self.features, self.features)
         lower_inverse = torch.linalg.solve_triangular(
-            identity, lower, upper=False, unitriangular=True
+            lower, identity, upper=False, unitriangular=True
         )
         weight_inverse = torch.linalg.solve_triangular(
-            lower_inverse, upper, upper=True, unitriangular=False
+            upper, lower_inverse, upper=True, unitriangular=False
         )
         return weight_inverse
 

--- a/nflows/transforms/lu.py
+++ b/nflows/transforms/lu.py
@@ -77,10 +77,10 @@ class LULinear(Linear):
         """
         lower, upper = self._create_lower_upper()
         outputs = inputs - self.bias
-        outputs, _ = torch.triangular_solve(
+        outputs, _ = torch.linalg.solve_triangular(
             outputs.t(), lower, upper=False, unitriangular=True
         )
-        outputs, _ = torch.triangular_solve(
+        outputs, _ = torch.linalg.solve_triangular(
             outputs, upper, upper=True, unitriangular=False
         )
         outputs = outputs.t()
@@ -107,10 +107,10 @@ class LULinear(Linear):
         """
         lower, upper = self._create_lower_upper()
         identity = torch.eye(self.features, self.features)
-        lower_inverse, _ = torch.triangular_solve(
+        lower_inverse, _ = torch.linalg.solve_triangular(
             identity, lower, upper=False, unitriangular=True
         )
-        weight_inverse, _ = torch.triangular_solve(
+        weight_inverse, _ = torch.linalg.solve_triangular(
             lower_inverse, upper, upper=True, unitriangular=False
         )
         return weight_inverse

--- a/nflows/transforms/qr.py
+++ b/nflows/transforms/qr.py
@@ -75,7 +75,7 @@ class QRLinear(Linear):
         outputs, _ = self.orthogonal.inverse(
             outputs
         )  # Ignore logabsdet since we know it's zero.
-        outputs = torch.linalg.solve_triangular(outputs.t(), upper, upper=True)
+        outputs = torch.linalg.solve_triangular(upper, outputs.t(), upper=True)
         outputs = outputs.t()
         logabsdet = -self.logabsdet()
         logabsdet = logabsdet * outputs.new_ones(outputs.shape[0])
@@ -101,7 +101,7 @@ class QRLinear(Linear):
         """
         upper = self._create_upper()
         identity = torch.eye(self.features, self.features)
-        upper_inv = torch.linalg.solve_triangular(identity, upper, upper=True)
+        upper_inv = torch.linalg.solve_triangular(upper, identity, upper=True)
         weight_inv, _ = self.orthogonal(upper_inv)
         return weight_inv
 

--- a/nflows/transforms/qr.py
+++ b/nflows/transforms/qr.py
@@ -75,7 +75,7 @@ class QRLinear(Linear):
         outputs, _ = self.orthogonal.inverse(
             outputs
         )  # Ignore logabsdet since we know it's zero.
-        outputs, _ = torch.triangular_solve(outputs.t(), upper, upper=True)
+        outputs = torch.linalg.solve_triangular(outputs.t(), upper, upper=True)
         outputs = outputs.t()
         logabsdet = -self.logabsdet()
         logabsdet = logabsdet * outputs.new_ones(outputs.shape[0])
@@ -101,7 +101,7 @@ class QRLinear(Linear):
         """
         upper = self._create_upper()
         identity = torch.eye(self.features, self.features)
-        upper_inv, _ = torch.triangular_solve(identity, upper, upper=True)
+        upper_inv = torch.linalg.solve_triangular(identity, upper, upper=True)
         weight_inv, _ = self.orthogonal(upper_inv)
         return weight_inv
 


### PR DESCRIPTION
From PyTorch 1.11 docs: [link](https://pytorch.org/docs/stable/generated/torch.triangular_solve.html)

> UserWarning: torch.triangular_solve is deprecated in favor of torch.linalg.solve_triangular and will be removed in a future PyTorch release.
> torch.linalg.solve_triangular has its arguments reversed and does not return a copy of one of the inputs.
> X = torch.triangular_solve(B, A).solution
> should be replaced with
> X = torch.linalg.solve_triangular(A, B).

This PR swaps in the new torch.linalg.solve_triangular() ([see docs](https://pytorch.org/docs/stable/generated/torch.linalg.solve_triangular.html#torch.linalg.solve_triangular)) with the arguments correctly swapped.
I tested it for sample generation in my use case and everything works fine without any UserWarning!

Cheers,
Francesco