### PR TITLE
Update lu.py to use torch.linalg.solve_triangular instead of deprecated torch.solve_triangular

### DIFF
--- a/nflows/transforms/lu.py
+++ b/nflows/transforms/lu.py
@@ -77,11 +77,11 @@ class LULinear(Linear):
         """
         lower, upper = self._create_lower_upper()
         outputs = inputs - self.bias
-        outputs, _ = torch.triangular_solve(
-            outputs.t(), lower, upper=False, unitriangular=True
+        outputs, _ = torch.linalg.solve_triangular(
+            lower, outputs.t(), upper=False, unitriangular=True
         )
-        outputs, _ = torch.triangular_solve(
-            outputs, upper, upper=True, unitriangular=False
+        outputs, _ = torch.linalg.solve_triangular(
+            upper, outputs, upper=True, unitriangular=False
         )
         outputs = outputs.t()
 
@@ -107,11 +107,11 @@ class LULinear(Linear):
         """
         lower, upper = self._create_lower_upper()
         identity = torch.eye(self.features, self.features)
-        lower_inverse, _ = torch.triangular_solve(
-            identity, lower, upper=False, unitriangular=True
+        lower_inverse = torch.linalg.solve_triangular(
+            lower, identity, upper=False, unitriangular=True
         )
-        weight_inverse, _ = torch.triangular_solve(
-            lower_inverse, upper, upper=True, unitriangular=False
+        weight_inverse = torch.linalg.solve_triangular(
+            upper, lower_inverse, upper=True, unitriangular=False
         )
         return weight_inverse
 


### PR DESCRIPTION
On pytorch 1.11, `torch.triangular_solve` is deprecated, which is used by the `flows.transforms.OneByOneConvolution` and `flows.transforms.LULinear` classes.

Source: https://pytorch.org/docs/stable/generated/torch.triangular_solve.html