### PR TITLE
add exp to transforms

### DIFF
--- a/nflows/transforms/__init__.py
+++ b/nflows/transforms/__init__.py
@@ -28,6 +28,7 @@ from nflows.transforms.linear import NaiveLinear
 from nflows.transforms.lu import LULinear
 from nflows.transforms.nonlinearities import (
     CompositeCDFTransform,
+    Exp,
     GatedLinearUnit,
     LeakyReLU,
     Logit,

--- a/nflows/transforms/nonlinearities.py
+++ b/nflows/transforms/nonlinearities.py
@@ -15,6 +15,26 @@ from nflows.transforms.base import (
 from nflows.utils import torchutils
 
 
+class Exp(Transform):
+    
+    def forward(self, inputs, context=None):
+        
+        outputs = torch.exp(inputs)
+        logabsdet = torch.sum(inputs, dim=-1)
+        
+        return outputs, logabsdet
+    
+    def inverse(self, inputs, context=None):
+        
+        if torch.min(inputs) <= 0.:
+            raise InputOutsideDomain()
+            
+        outputs = torch.log(inputs)
+        logabsdet = -torch.sum(outputs, dim=-1)
+        
+        return outputs, logabsdet
+
+
 class Tanh(Transform):
     def forward(self, inputs, context=None):
         outputs = torch.tanh(inputs)

--- a/tests/transforms/nonlinearities_test.py
+++ b/tests/transforms/nonlinearities_test.py
@@ -10,6 +10,16 @@ from nflows.transforms.base import InputOutsideDomain
 from tests.transforms.transform_test import TransformTest
 
 
+class ExpTest(TransformTest):
+    def test_raises_domain_exception(self):
+        shape = [2, 3, 4]
+        transform = nl.Exp()
+        for value in [-1.0, 0.0]:
+            with self.assertRaises(InputOutsideDomain):
+                inputs = torch.full(shape, value)
+                transform.inverse(inputs)
+
+
 class TanhTest(TransformTest):
     def test_raises_domain_exception(self):
         shape = [2, 3, 4]
@@ -102,6 +112,7 @@ class NonlinearitiesTest(TransformTest):
         shape = [5, 10, 15]
         inputs = torch.rand(batch_size, *shape)
         transforms = [
+            nl.Exp(),
             nl.Tanh(),
             nl.LogTanh(),
             nl.LeakyReLU(),
@@ -120,6 +131,7 @@ class NonlinearitiesTest(TransformTest):
         shape = [5, 10, 15]
         inputs = torch.rand(batch_size, *shape)
         transforms = [
+            nl.Exp(),
             nl.Tanh(),
             nl.LogTanh(),
             nl.LeakyReLU(),
@@ -138,6 +150,7 @@ class NonlinearitiesTest(TransformTest):
         shape = [5, 10, 15]
         inputs = torch.rand(batch_size, *shape)
         transforms = [
+            nl.Exp(),
             nl.Tanh(),
             nl.LogTanh(),
             nl.LeakyReLU(),


### PR DESCRIPTION
Implementation of exponential transform. Useful for, e.g., transforming from $\mathbb{R}$ to a one-side bounded domain $(a, \infty)$ or $(-\infty, a)$ via composition with an affine transform.