### PR TITLE
allow negative scale in PointwiseAffineTransform

### DIFF
--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -44,11 +44,11 @@ class PointwiseAffineTransform(Transform):
     def _batch_logabsdet(self, batch_shape: Iterable[int]) -> Tensor:
         """Return log abs det with input batch shape."""
 
-        if self._log_scale.numel() > 1:
+        if self._log_abs_scale.numel() > 1:
             return self._log_abs_scale.expand(batch_shape).sum()
         else:
-            # When log_scale is a scalar, we use n*log_scale, which is more
-            # numerically accurate than \sum_1^n log_scale.
+            # When log_abs_scale is a scalar, we use n*log_abs_scale, which is more
+            # numerically accurate than \sum_1^n log_abs_scale.
             return self._log_abs_scale * torch.Size(batch_shape).numel()
 
     def forward(self, inputs: Tensor, context=Optional[Tensor]) -> Tuple[Tensor]:

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -30,15 +30,15 @@ class PointwiseAffineTransform(Transform):
         super().__init__()
         shift, scale = map(torch.as_tensor, (shift, scale))
 
-        if not (scale > 0.0).all():
-            raise ValueError("Scale must be strictly positive.")
+        if (scale == 0.0).any():
+            raise ValueError("Scale must be non-zero.")
 
         self.register_buffer("_shift", shift)
         self.register_buffer("_scale", scale)
 
     @property
     def _log_scale(self) -> Tensor:
-        return torch.log(self._scale)
+        return torch.log(torch.abs(self._scale))
 
     # XXX Memoize result on first run?
     def _batch_logabsdet(self, batch_shape: Iterable[int]) -> Tensor:

--- a/nflows/transforms/standard.py
+++ b/nflows/transforms/standard.py
@@ -37,7 +37,7 @@ class PointwiseAffineTransform(Transform):
         self.register_buffer("_scale", scale)
 
     @property
-    def _log_scale(self) -> Tensor:
+    def _log_abs_scale(self) -> Tensor:
         return torch.log(torch.abs(self._scale))
 
     # XXX Memoize result on first run?
@@ -45,11 +45,11 @@ class PointwiseAffineTransform(Transform):
         """Return log abs det with input batch shape."""
 
         if self._log_scale.numel() > 1:
-            return self._log_scale.expand(batch_shape).sum()
+            return self._log_abs_scale.expand(batch_shape).sum()
         else:
             # When log_scale is a scalar, we use n*log_scale, which is more
             # numerically accurate than \sum_1^n log_scale.
-            return self._log_scale * torch.Size(batch_shape).numel()
+            return self._log_abs_scale * torch.Size(batch_shape).numel()
 
     def forward(self, inputs: Tensor, context=Optional[Tensor]) -> Tuple[Tensor]:
         batch_size, *batch_shape = inputs.size()

--- a/tests/transforms/standard_test.py
+++ b/tests/transforms/standard_test.py
@@ -61,6 +61,8 @@ class AffineScalarTransformTest(TransformTest):
         test_case(None, 2.0, inputs + 2.0, 0.)
         test_case(2.0, None, inputs * 2.0, np.log(2.0))
         test_case(2.0, 2.0, inputs * 2.0 + 2.0, np.log(2.0))
+        test_case(-1.0, None, -inputs, 0.0)
+        test_case(-2.0, 2.0, inputs * -2.0 + 2.0, np.log(2.0))
 
     def test_inverse(self):
         batch_size = 10
@@ -82,6 +84,8 @@ class AffineScalarTransformTest(TransformTest):
         test_case(None, 2.0, inputs - 2.0, 0.)
         test_case(2.0, None, inputs / 2.0, -np.log(2.0))
         test_case(2.0, 2.0, (inputs - 2.0) / 2.0, -np.log(2.0))
+        test_case(-1.0, None, -inputs, 0.0)
+        test_case(-2.0, 2.0, (inputs - 2.0) / -2.0, -np.log(2.0))
 
     def test_forward_inverse_are_consistent(self):
         batch_size = 10
@@ -96,6 +100,8 @@ class AffineScalarTransformTest(TransformTest):
         test_case(None, 2.0)
         test_case(2.0, None)
         test_case(2.0, 2.0)
+        test_case(-1.0, None)
+        test_case(-2.0, 2.0)
 
 
 if __name__ == "__main__":

--- a/tests/transforms/standard_test.py
+++ b/tests/transforms/standard_test.py
@@ -102,6 +102,13 @@ class AffineScalarTransformTest(TransformTest):
         test_case(2.0, 2.0)
         test_case(-1.0, None)
         test_case(-2.0, 2.0)
+        
+    def test_raises_value_error(self):    
+        def test_case(shift):
+            with self.assertRaises(ValueError):
+                transform = standard.AffineTransform(scale=0.0, shift=shift)
+            
+        test_case(None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current implementation of PointwiseAffineTransform allows only positive values for the scale. As far as I can tell, this isn't necessary and only zero values (which make the transform no longer bijective) need to be rejected. Only the absolute value of the scale enters the log prob conversion while the scale and its reciprocal itself enters the transform of samples.