### PR TITLE
float precision check in rational quadratic spline discriminant

### DIFF
--- a/nflows/transforms/splines/rational_quadratic.py
+++ b/nflows/transforms/splines/rational_quadratic.py
@@ -139,6 +139,10 @@ def rational_quadratic_spline(
         c = -input_delta * (inputs - input_cumheights)
 
         discriminant = b.pow(2) - 4 * a * c
+
+        float_precision_mask = (torch.abs(discriminant)/(b.pow(2) + 1e-8)) < 1e-6
+        discriminant[float_precision_mask] = 0
+        
         assert (discriminant >= 0).all()
 
         root = (2 * c) / (-b - torch.sqrt(discriminant))


### PR DESCRIPTION
Hello, and thanks again for the terrific package

The present pull request address an issue me and my group have been facing a lot when using `model.sample()`.
When inverting a rational quadratic spline one must calculate the value $\sqrt{b^{2} - 4ac}$ where a, b, c are defined as in eq 6 and onward in the original paper ([Neural Spline Flows](https://arxiv.org/pdf/1906.04032.pdf)).

The rational quadratic splines code has a check to ensure that this discriminant satisfies $b^2 -4ac >= 0$:

```
        discriminant = b.pow(2) - 4 * a * c
        assert (discriminant >= 0).all()
```

However, if the two components are equal up to the float precision, $b^2 = 4ac$, instead of their difference being 0 as expected, it is sometimes set to an arbitrary bit value with arbitrary sign (e.g. `-3.0518e-5`), which can proc the AssertionError and cause a crash.

To avoid this unwanted behaviour we implemented a simple check on the relative magnitude of the discriminant, which seems to be solving the issue effectively in our use case:

```
        discriminant = b.pow(2) - 4 * a * c

        float_precision_mask = (torch.abs(discriminant)/(b.pow(2) + 1e-8)) < 1e-6
        discriminant[float_precision_mask] = 0
        
        assert (discriminant >= 0).all()
```

Please let me know if you need anything else on my part,
Best regards,
Francesco

> PLEASE NOTE: on my fork this commit causes two tests to crash with the following errors:
FAILED tests/transforms/autoregressive_test.py::MaskedPiecewiseQuadraticAutoregressiveTranformTest::test_forward_inverse_are_consistent - AssertionError: The tensors are different!
FAILED tests/transforms/splines/cubic_test.py::CubicSplineTest::test_forward_inverse_are_consistent - AssertionError: The tensors are different!
However this errors seems to be related to two transforms left untouched by my pull request, so I am not sure if they are actually related to my modification. Do you have any idea as to why they may be crashing?